### PR TITLE
Fix backend image display in frontend

### DIFF
--- a/app/dashboard/live/page.tsx
+++ b/app/dashboard/live/page.tsx
@@ -205,6 +205,14 @@ export default function LiveDetection() {
                     ({(liveResult.confidence * 100).toFixed(1)}%)
                   </span>
                 </p>
+                <div className="aspect-video relative bg-gray-100 rounded-lg overflow-hidden mt-4">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={liveResult.processed_image}
+                    alt="Live Detection Result"
+                    className="w-full h-full object-contain"
+                  />
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
Add code to render the processed image from the WebSocket response in the live detection results.

* Add a new `div` element to display the processed image in the live result section.
* Add an `img` element to show the processed image with the `src` attribute set to `liveResult.processed_image`.
* Apply appropriate CSS classes for styling the image container and the image itself.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/RecycleX/pull/1?shareId=455896ef-18dc-4db4-85c3-aa9a4acc8714).